### PR TITLE
DEVOPS-4595: update 1Password version and install a local one instead

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ export const g = "05";
 
 export const device: Device = {
   clientName: "1Password for Web",
-  clientVersion: "945",
+  clientVersion: "1065",
   model: "73.0.3683.103",
   name: "Chrome",
   osName: "MacOSX",

--- a/src/services/Onepassword.ts
+++ b/src/services/Onepassword.ts
@@ -73,7 +73,7 @@ export class Onepassword {
     const message = {
       sessionID: this.session.id,
       clientVerifyHash,
-      client: "1Password for Web/945",
+      client: "1Password for Web/1065",
       device: this.device
     };
     const { serverVerifyHash } = await this.requestService.secureRequest(

--- a/src/services/Request.ts
+++ b/src/services/Request.ts
@@ -27,7 +27,7 @@ export default class {
   ): Promise<any> {
     headers = {
       "x-requested-with": "XMLHttpRequest",
-      "x-agilebits-client": "1Password for Web/945",
+      "x-agilebits-client": "1Password for Web/1065",
       "User-Agent":
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36",
       ...(method !== "GET" && { "Content-Type": "application/json" }),


### PR DESCRIPTION

**Description**

- Just like what we did [here](https://github.com/privicy/onepassword-web-client/pull/8), this PR continue to upgrade client version to 1065(latest as now)
 

Fixes [#DEVOPS-4595](https://team-turo.atlassian.net//browse/DEVOPS-4595)

**Changes**

* fix: change client version to 1065

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
